### PR TITLE
refactor: remove `importlib-metadata-fallback`

### DIFF
--- a/bandit/__init__.py
+++ b/bandit/__init__.py
@@ -2,10 +2,7 @@
 # Copyright 2014 Hewlett-Packard Development Company, L.P.
 #
 # SPDX-License-Identifier: Apache-2.0
-try:
-    from importlib import metadata
-except ImportError:
-    import importlib_metadata as metadata
+from importlib import metadata
 
 from bandit.core import config  # noqa
 from bandit.core import context  # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ PyYAML>=5.3.1 # MIT
 stevedore>=1.20.0 # Apache-2.0
 colorama>=0.3.9;platform_system=="Windows" # BSD License (3 clause)
 rich # MIT
-importlib-metadata;python_version<"3.8" # Apache-2.0


### PR DESCRIPTION
Python 3.7 support has been removed in
https://github.com/PyCQA/bandit/pull/1034, so the `importlib-metadata` fallback, is no longer required, as it was only need for Python < 3.8.